### PR TITLE
Duplicate '<<' (merge) keys should work transparently

### DIFF
--- a/_test/test_anchor.py
+++ b/_test/test_anchor.py
@@ -491,6 +491,43 @@ class TestMergeKeysValues:
         assert 'a' not in d
         assert 'a' in d2
 
+    def test_dup_merge(self):
+        from ruyaml import YAML
+
+        yaml = YAML()
+        yaml.allow_duplicate_keys = True
+        d = yaml.load(
+            """\
+        foo: &f
+          a: a
+        foo2: &g
+          b: b
+        all:
+          <<: *f
+          <<: *g
+        """
+        )['all']
+        assert d == {'a': 'a', 'b': 'b'}
+
+    def test_dup_merge_fail(self):
+        from ruyaml import YAML
+        from ruyaml.constructor import DuplicateKeyError
+
+        yaml = YAML()
+        yaml.allow_duplicate_keys = False
+        with pytest.raises(DuplicateKeyError):
+            yaml.load(
+                """\
+            foo: &f
+              a: a
+            foo2: &g
+              b: b
+            all:
+              <<: *f
+              <<: *g
+            """
+            )
+
 
 class TestDuplicateKeyThroughAnchor:
     def test_duplicate_key_00(self):

--- a/lib/ruyaml/constructor.py
+++ b/lib/ruyaml/constructor.py
@@ -378,11 +378,7 @@ class SafeConstructor(BaseConstructor):
         while index < len(node.value):
             key_node, value_node = node.value[index]
             if key_node.tag == u'tag:yaml.org,2002:merge':
-                if merge:  # double << key
-                    if self.allow_duplicate_keys:
-                        del node.value[index]
-                        index += 1
-                        continue
+                if merge and not self.allow_duplicate_keys:
                     args = [
                         'while constructing a mapping',
                         node.start_mark,
@@ -390,7 +386,7 @@ class SafeConstructor(BaseConstructor):
                         key_node.start_mark,
                         """
                         To suppress this check see:
-                           http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys
+                        http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys
                         """,
                         """\
                         Duplicate keys will become an error in future releases, and are errors
@@ -1346,11 +1342,7 @@ class RoundTripConstructor(SafeConstructor):
         while index < len(node.value):
             key_node, value_node = node.value[index]
             if key_node.tag == u'tag:yaml.org,2002:merge':
-                if merge_map_list:  # double << key
-                    if self.allow_duplicate_keys:
-                        del node.value[index]
-                        index += 1
-                        continue
+                if merge_map_list and not self.allow_duplicate_keys:
                     args = [
                         'while constructing a mapping',
                         node.start_mark,


### PR DESCRIPTION
when "allow_duplicate_keys" is on.

Fixes #43.