### PR TITLE
Remove backwards compatibility cruft

### DIFF
--- a/_doc/api.rst
+++ b/_doc/api.rst
@@ -194,61 +194,42 @@ for reading resp. writing.
 
 Loading and dumping using the ``SafeLoader``::
 
-    if ruyaml.version_info < (0, 15):
-        data = yaml.safe_load(istream)
-        yaml.safe_dump(data, ostream)
-    else:
-        yml = ruyaml.YAML(typ='safe', pure=True)  # 'safe' load and dump
-        data = yml.load(istream)
-        yml.dump(data, ostream)
+    yml = ruyaml.YAML(typ='safe', pure=True)  # 'safe' load and dump
+    data = yml.load(istream)
+    yml.dump(data, ostream)
 
 Loading with the ``CSafeLoader``, dumping with
 ``RoundTripLoader``. You need two ``YAML`` instances, but each of them
 can be re-used::
 
-    if ruyaml.version_info < (0, 15):
-        data = yaml.load(istream, Loader=yaml.CSafeLoader)
-        yaml.round_trip_dump(data, ostream, width=1000, explicit_start=True)
-    else:
-        yml = ruyaml.YAML(typ='safe')
-        data = yml.load(istream)
-        ymlo = ruyaml.YAML()  # or yaml.YAML(typ='rt')
-        ymlo.width = 1000
-        ymlo.explicit_start = True
-        ymlo.dump(data, ostream)
+    yml = ruyaml.YAML(typ='safe')
+    data = yml.load(istream)
+    ymlo = ruyaml.YAML()  # or yaml.YAML(typ='rt')
+    ymlo.width = 1000
+    ymlo.explicit_start = True
+    ymlo.dump(data, ostream)
 
 Loading and dumping from ``pathlib.Path`` instances using the
 round-trip-loader::
 
     # in myyaml.py
-    if ruyaml.version_info < (0, 15):
-        class MyYAML(yaml.YAML):
-            def __init__(self):
-                yaml.YAML.__init__(self)
-                self.preserve_quotes = True
-                self.indent(mapping=4, sequence=4, offset=2)
+    class MyYAML(yaml.YAML):
+        def __init__(self):
+            yaml.YAML.__init__(self)
+            self.preserve_quotes = True
+            self.indent(mapping=4, sequence=4, offset=2)
     # in your code
-    try:
-        from myyaml import MyYAML
-    except (ModuleNotFoundError, ImportError):
-        if ruyaml.version_info >= (0, 15):
-            raise
+    from myyaml import MyYAML
 
     # some pathlib.Path
     from pathlib import Path
     inf = Path('/tmp/in.yaml')
     outf = Path('/tmp/out.yaml')
 
-    if ruyaml.version_info < (0, 15):
-        with inf.open() as ifp:
-             data = yaml.round_trip_load(ifp, preserve_quotes=True)
-        with outf.open('w') as ofp:
-             yaml.round_trip_dump(data, ofp, indent=4, block_seq_indent=2)
-    else:
-        yml = MyYAML()
-        # no need for with statement when using pathlib.Path instances
-        data = yml.load(inf)
-        yml.dump(data, outf)
+    yml = MyYAML()
+    # no need for with statement when using pathlib.Path instances
+    data = yml.load(inf)
+    yml.dump(data, outf)
 
 +++++++++++++++++++++
 Reason for API change

--- a/_test/test_anchor.py
+++ b/_test/test_anchor.py
@@ -494,7 +494,7 @@ class TestMergeKeysValues:
 
 class TestDuplicateKeyThroughAnchor:
     def test_duplicate_key_00(self):
-        from ruyaml import round_trip_load, safe_load, version_info
+        from ruyaml import round_trip_load, safe_load
         from ruyaml.constructor import DuplicateKeyError, DuplicateKeyFutureWarning
 
         s = dedent(
@@ -506,22 +506,13 @@ class TestDuplicateKeyThroughAnchor:
             *anchor : duplicate key
         """
         )
-        if version_info < (0, 15, 1):
-            pass
-        elif version_info < (0, 16, 0):
-            with pytest.warns(DuplicateKeyFutureWarning):
-                safe_load(s)
-            with pytest.warns(DuplicateKeyFutureWarning):
-                round_trip_load(s)
-        else:
-            with pytest.raises(DuplicateKeyError):
-                safe_load(s)
-            with pytest.raises(DuplicateKeyError):
-                round_trip_load(s)
+        with pytest.raises(DuplicateKeyError):
+            safe_load(s)
+        with pytest.raises(DuplicateKeyError):
+            round_trip_load(s)
 
     def test_duplicate_key_01(self):
         # so issue https://stackoverflow.com/a/52852106/1307905
-        from ruyaml import version_info
         from ruyaml.constructor import DuplicateKeyError
 
         s = dedent(
@@ -534,15 +525,12 @@ class TestDuplicateKeyThroughAnchor:
           <<: *help-name
         """
         )
-        if version_info < (0, 15, 1):
-            pass
-        else:
-            with pytest.raises(DuplicateKeyError):
-                yaml = YAML(typ='safe')
-                yaml.load(s)
-            with pytest.raises(DuplicateKeyError):
-                yaml = YAML()
-                yaml.load(s)
+        with pytest.raises(DuplicateKeyError):
+            yaml = YAML(typ='safe')
+            yaml.load(s)
+        with pytest.raises(DuplicateKeyError):
+            yaml = YAML()
+            yaml.load(s)
 
 
 class TestFullCharSetAnchors:

--- a/_test/test_anchor.py
+++ b/_test/test_anchor.py
@@ -495,7 +495,7 @@ class TestMergeKeysValues:
 class TestDuplicateKeyThroughAnchor:
     def test_duplicate_key_00(self):
         from ruyaml import round_trip_load, safe_load
-        from ruyaml.constructor import DuplicateKeyError, DuplicateKeyFutureWarning
+        from ruyaml.constructor import DuplicateKeyError
 
         s = dedent(
             """\

--- a/lib/ruyaml/compat.py
+++ b/lib/ruyaml/compat.py
@@ -160,20 +160,6 @@ def check_anchorname_char(ch):
     return check_namespace_char(ch)
 
 
-def version_tnf(t1, t2=None):
-    # type: (Any, Any) -> Any
-    """
-    return True if ruyaml version_info < t1, None if t2 is specified and bigger else False
-    """
-    from ruyaml import version_info  # NOQA
-
-    if version_info < t1:
-        return True
-    if t2 is not None and version_info < t2:
-        return None
-    return False
-
-
 class MutableSliceableSequence(MutableSequence):  # type: ignore
     __slots__ = ()
 

--- a/lib/ruyaml/constructor.py
+++ b/lib/ruyaml/constructor.py
@@ -22,7 +22,7 @@ from ruyaml.comments import (
 )
 from ruyaml.compat import MutableMapping  # noqa; type: ignore; type: ignore
 from ruyaml.compat import builtins_module  # NOQA
-from ruyaml.compat import Hashable, MutableSequence, ordereddict, version_tnf
+from ruyaml.compat import Hashable, MutableSequence, ordereddict
 
 # fmt: off
 from ruyaml.error import (
@@ -88,7 +88,7 @@ class BaseConstructor:
         self.state_generators = []  # type: List[Any]
         self.deep_construct = False
         self._preserve_quotes = preserve_quotes
-        self.allow_duplicate_keys = version_tnf((0, 15, 1), (0, 16))
+        self.allow_duplicate_keys = False
 
     @property
     def composer(self):


### PR DESCRIPTION
We don't need tests or documentation for old ruamel.yaml versions here.