### PR TITLE
Remove setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,2 @@
-include README.rst LICENSE CHANGES setup.py
 prune ext*
 prune clib*
-recursive-include lib *

--- a/_doc/contributing.rst
+++ b/_doc/contributing.rst
@@ -27,7 +27,7 @@ In my experience it is best to use two ``virtualenv`` environments, one with the
 latest Python from the 2.7 series, the other with 3.5 or 3.6. In the
 site-packages directory of each virtualenv make a soft link to the ruyaml
 directory of your (cloned and checked out) copy of the repository. Do not under
-any circumstances run ``pip install -e .`` or ``python setup.py -e .`` it will
+any circumstances run ``pip install -e .`` it will
 not work (at least not until these commands are fixed to support packages with
 namespaces).
 
@@ -38,7 +38,7 @@ pass without warning/error, you can create your pull-request.
 Flake
 +++++
 
-The `Flake8 <https://flake8.pycqa.org>`_ configuration is part of ``setup.py``::
+The `Flake8 <https://flake8.pycqa.org>`_ configuration is part of ``setup.cfg``::
 
     [flake8]
     show-source = True

--- a/_doc/contributing.ryd
+++ b/_doc/contributing.ryd
@@ -56,7 +56,7 @@ In my experience it is best to use two ``virtualenv`` environments, one with the
 latest Python from the 2.7 series, the other with 3.5 or 3.6. In the
 site-packages directory of each virtualenv make a soft link to the ruamel
 directory of your (cloned and checked out) copy of the repository. Do not under
-any circumstances run ``pip install -e .`` or ``python setup.py -e .`` it will
+any circumstances run ``pip install -e .`` it will
 not work (at least not until these commands are fixed to support packages with
 namespaces).
 
@@ -114,7 +114,6 @@ automatically be reverted, even assuming your PR is accepted as is.
 Consider the following files **read-only** (if you think changes need to made these,
 contact me)::
 
-   setup.py
    tox.ini
    LICENSE
    _ryd/conf.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[aliases]
-dists = clean --all sdist bdist_wheel
-
-[bdist_wheel]
-universal = 1
-
 [metadata]
 name = ruyaml
 url = https://github.com/pycontribs/ruyaml
@@ -63,11 +57,6 @@ zip_safe = True
 install_requires =
     distro>=1.3.0
     setuptools>=39.0
-
-# These are required during `setup.py` run:
-setup_requires =
-    setuptools_scm >= 1.15.0
-    setuptools_scm_git_archive >= 1.0
 
 [options.extras_require]
 docs =

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-# coding: utf-8
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup(use_scm_version=True)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ skip_missing_interpreters = False
 
 [testenv]
 description = Unittest using {basepython}
-install_command = pip install --disable-pip-version-check {opts} {packages}
 commands =
     /bin/bash -c 'pytest _test/test_*.py'
 deps =
@@ -25,8 +24,8 @@ allowlist_externals =
 [testenv:docs]
 description = Build docs
 basepython = python3.8
-extras =
-    docs
+deps =
+    --editable .[docs]
 commands =
     make singlehtml
 changedir = {toxinidir}/_doc


### PR DESCRIPTION
setup.py was deprecated years ago and kept only for compatibility with very old versions of python and pip.

It is time to remove it as this ensures that the newer PEP-517 packaging is used.

As tox still have some bugs related to testing of repositories without a setup.py, we includes the required workarounds for keeping it working.

Example of similar drop https://github.com/ansible-community/ansible-lint/pull/1762/files