### PR TITLE
fixed iterable reassignment within a for loop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/lib/ruyaml/comments.py
+++ b/lib/ruyaml/comments.py
@@ -1057,9 +1057,9 @@ class CommentedMap(ordereddict, CommentedBase):
 
     def add_yaml_merge(self, value):
         # type: (Any) -> None
-        for v in value:
-            v[1].add_referent(self)
-            for k, v in v[1].items():
+        for val in value:
+            val[1].add_referent(self)
+            for k, v in val[1].items():
                 if ordereddict.__contains__(self, k):
                     continue
                 ordereddict.__setitem__(self, k, v)


### PR DESCRIPTION
This PR fixes a for loop that reassigns its own iterable each pass.

See failing tox checks here: https://github.com/pycontribs/ruyaml/runs/5976754116?check_suite_focus=true