### PR TITLE
Clean up build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
   "pip >= 19.3.1",
   "setuptools >= 42",
   "setuptools_scm[toml] >= 3.5.0",
-  "setuptools_scm_git_archive >= 1.1",
   "wheel >= 0.33.6",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I think `setuptools_scm_git_archive` does not need in pyproject.toml since a `.git_archival.txt` does not exist.

closes https://github.com/pycontribs/ruyaml/issues/106