### PR TITLE
fix: flake8-bugbear error in test_appliance.py

### DIFF
--- a/_test/lib/test_appliance.py
+++ b/_test/lib/test_appliance.py
@@ -141,7 +141,7 @@ def display(results, verbose):
         sys.stdout.write('=' * 75 + '\n')
         sys.stdout.write('%s(%s): %s\n' % (name, ', '.join(filenames), kind))
         if kind == 'ERROR':
-            traceback.print_exception(file=sys.stdout, *info)
+            traceback.print_exception(*info, file=sys.stdout)
         else:
             sys.stdout.write('Traceback (most recent call last):\n')
             traceback.print_tb(info[2], file=sys.stdout)


### PR DESCRIPTION
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

```
_test/lib/test_appliance.py:144:56: B026 Star-arg unpacking after a keyword argument is strongly discouraged,
because it only works when the keyword parameter is declared after all parameters supplied by the unpacked sequence,
and this change of ordering can surprise and mislead readers.
            traceback.print_exception(file=sys.stdout, *info)
                                                       ^
```