### PR TITLE
Bugfix for `flow_map_start`.

### DIFF
--- a/_test/test_issues.py
+++ b/_test/test_issues.py
@@ -6,13 +6,13 @@ import pytest  # type: ignore  # NOQA
 
 # cannot do "from .roundtrip" because of pytest, so mypy cannot find this
 from roundtrip import (  # type: ignore
+    YAML,
     dedent,
     na_round_trip,
     round_trip,
     round_trip_dump,
     round_trip_load,
     save_and_run,
-    YAML,
 )
 
 

--- a/_test/test_z_check_debug_leftovers.py
+++ b/_test/test_z_check_debug_leftovers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest  # type: ignore # NOQA
 from roundtrip import dedent, round_trip_dump, round_trip_load  # type: ignore
+
 from ruyaml.emitter import Emitter
 
 
@@ -48,7 +49,8 @@ class TestLeftOverDebug:
         - {  }
         - [ 3.14 , 42 ]
         - [  ]
-        """)
+        """
+        )
         d = round_trip_load(s)
 
         current_map_start = Emitter.flow_map_start

--- a/_test/test_z_check_debug_leftovers.py
+++ b/_test/test_z_check_debug_leftovers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest  # type: ignore # NOQA
 from roundtrip import dedent, round_trip_dump, round_trip_load  # type: ignore
+from ruyaml.emitter import Emitter
 
 
 class TestLeftOverDebug:
@@ -36,5 +37,45 @@ class TestLeftOverDebug:
         )
         d = round_trip_load(s)
         round_trip_dump(d, sys.stdout)
+        out, err = capsys.readouterr()
+        assert out == s
+
+    def test_02(self, capsys: Any) -> None:
+        s = dedent(
+            """
+        - 1
+        - { f: 3.14 , g: 42 }
+        - {  }
+        - [ 3.14 , 42 ]
+        - [  ]
+        """)
+        d = round_trip_load(s)
+
+        current_map_start = Emitter.flow_map_start
+        current_map_end = Emitter.flow_map_end
+        current_map_separator = Emitter.flow_map_separator
+        current_seq_start = Emitter.flow_seq_start
+        current_seq_end = Emitter.flow_seq_end
+        current_seq_separator = Emitter.flow_seq_separator
+
+        Emitter.flow_map_start = '{ '
+        Emitter.flow_map_end = ' }'
+        Emitter.flow_map_separator = ' ,'
+
+        Emitter.flow_seq_start = '[ '
+        Emitter.flow_seq_end = ' ]'
+        Emitter.flow_seq_separator = ' ,'
+
+        try:
+            round_trip_dump(d, sys.stdout)
+        finally:
+            Emitter.flow_map_start = current_map_start
+            Emitter.flow_map_end = current_map_end
+            Emitter.flow_map_separator = current_map_separator
+
+            Emitter.flow_seq_start = current_seq_start
+            Emitter.flow_seq_end = current_seq_end
+            Emitter.flow_seq_separator = current_seq_separator
+
         out, err = capsys.readouterr()
         assert out == s

--- a/_test/test_z_data.py
+++ b/_test/test_z_data.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
-import sys
 import os
+import sys
 import warnings  # NOQA
 from pathlib import Path
 from typing import Any, List, Optional, Tuple

--- a/lib/ruyaml/composer.py
+++ b/lib/ruyaml/composer.py
@@ -7,13 +7,13 @@ from ruyaml.compat import nprint, nprintf  # NOQA
 from ruyaml.error import MarkedYAMLError, ReusedAnchorWarning
 from ruyaml.events import (
     AliasEvent,
-    MappingStartEvent,
     MappingEndEvent,
+    MappingStartEvent,
     ScalarEvent,
-    SequenceStartEvent,
     SequenceEndEvent,
-    StreamStartEvent,
+    SequenceStartEvent,
     StreamEndEvent,
+    StreamStartEvent,
 )
 from ruyaml.nodes import MappingNode, ScalarNode, SequenceNode
 

--- a/lib/ruyaml/constructor.py
+++ b/lib/ruyaml/constructor.py
@@ -8,29 +8,45 @@ import warnings
 from collections.abc import Hashable, MutableMapping, MutableSequence  # type: ignore
 from datetime import timedelta as TimeDelta
 
-# fmt: off
-from ruyaml.error import (MarkedYAMLError, MarkedYAMLFutureWarning,
-                          MantissaNoDotYAML1_1Warning)
-from ruyaml.nodes import *                               # NOQA
-from ruyaml.nodes import (SequenceNode, MappingNode, ScalarNode)
-from ruyaml.compat import (builtins_module, # NOQA
-                           nprint, nprintf, version_tnf)
-from ruyaml.compat import ordereddict
+from ruyaml.comments import *  # NOQA
+from ruyaml.comments import (
+    C_KEY_EOL,
+    C_KEY_POST,
+    C_KEY_PRE,
+    C_VALUE_EOL,
+    C_VALUE_POST,
+    C_VALUE_PRE,
+    CommentedKeyMap,
+    CommentedKeySeq,
+    CommentedMap,
+    CommentedOrderedMap,
+    CommentedSeq,
+    CommentedSet,
+    TaggedScalar,
+)
+from ruyaml.compat import builtins_module  # NOQA
+from ruyaml.compat import nprint, nprintf, ordereddict, version_tnf
 
-from ruyaml.tag import Tag
-from ruyaml.comments import *                               # NOQA
-from ruyaml.comments import (CommentedMap, CommentedOrderedMap, CommentedSet,
-                             CommentedKeySeq, CommentedSeq, TaggedScalar,
-                             CommentedKeyMap,
-                             C_KEY_PRE, C_KEY_EOL, C_KEY_POST,
-                             C_VALUE_PRE, C_VALUE_EOL, C_VALUE_POST,
-                             )
-from ruyaml.scalarstring import (SingleQuotedScalarString, DoubleQuotedScalarString,
-                                 LiteralScalarString, FoldedScalarString,
-                                 PlainScalarString, ScalarString)
-from ruyaml.scalarint import ScalarInt, BinaryInt, OctalInt, HexInt, HexCapsInt
-from ruyaml.scalarfloat import ScalarFloat
+# fmt: off
+from ruyaml.error import (
+    MantissaNoDotYAML1_1Warning,
+    MarkedYAMLError,
+    MarkedYAMLFutureWarning,
+)
+from ruyaml.nodes import *  # NOQA
+from ruyaml.nodes import MappingNode, ScalarNode, SequenceNode
 from ruyaml.scalarbool import ScalarBoolean
+from ruyaml.scalarfloat import ScalarFloat
+from ruyaml.scalarint import BinaryInt, HexCapsInt, HexInt, OctalInt, ScalarInt
+from ruyaml.scalarstring import (
+    DoubleQuotedScalarString,
+    FoldedScalarString,
+    LiteralScalarString,
+    PlainScalarString,
+    ScalarString,
+    SingleQuotedScalarString,
+)
+from ruyaml.tag import Tag
 from ruyaml.timestamp import TimeStamp
 from ruyaml.util import create_timestamp, timestamp_regexp
 

--- a/lib/ruyaml/emitter.py
+++ b/lib/ruyaml/emitter.py
@@ -596,7 +596,7 @@ class Emitter:
         if isinstance(self.event, MappingEndEvent):
             self.indent = self.indents.pop()
             popped = self.flow_context.pop()
-            assert popped == '{'  # empty flow mapping
+            assert popped == self.flow_map_start  # empty flow mapping
             self.write_indicator(self.flow_map_end, False)
             if self.event.comment and self.event.comment[0]:
                 # eol comment on empty mapping
@@ -621,7 +621,7 @@ class Emitter:
             #     self.write_pre_comment(self.event)
             self.indent = self.indents.pop()
             popped = self.flow_context.pop()
-            assert popped in ['{', '']
+            assert popped in [self.flow_map_start, '']
             if self.canonical:
                 self.write_indicator(self.flow_map_separator, False)
                 self.write_indent()

--- a/lib/ruyaml/main.py
+++ b/lib/ruyaml/main.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import glob
+import warnings
 from importlib import import_module
 from io import BytesIO, StringIO
 from typing import TYPE_CHECKING, Any, List, Optional, Text, Union
-import warnings
 
 import ruyaml
 from ruyaml.comments import C_PRE, CommentedMap, CommentedSeq
@@ -21,7 +21,6 @@ from ruyaml.error import UnsafeLoaderWarning, YAMLError  # NOQA
 from ruyaml.events import *  # NOQA
 from ruyaml.loader import BaseLoader  # NOQA
 from ruyaml.loader import Loader  # NOQA
-from ruyaml.loader import Loader as UnsafeLoader
 from ruyaml.loader import RoundTripLoader, SafeLoader  # NOQA
 from ruyaml.nodes import *  # NOQA
 from ruyaml.representer import (


### PR DESCRIPTION
To my best understanding, in 4e5edc9, the `flow_map_*` and `flow_seq_*` class variables were added to allow different formatting for flow mappings and flow sequences. However, it seems that these are currently not functional due to an assert.

This commit makes a small change to allow, in particular, the `flow_map_start` variable to be set and adds a test to help prevent a future regression.