### PR TITLE
Keep the eol comment on an empty block sequence entry

### DIFF
--- a/_test/test_comments.py
+++ b/_test/test_comments.py
@@ -947,6 +947,27 @@ class TestEmptyValueBeforeComments:
         """
         )
 
+    def test_empty_seq_entry_eol_comment_roundtrip(self) -> None:
+        # an empty (null) block sequence entry that carries an end-of-line
+        # comment must keep that comment attached to the entry itself, the
+        # same way an empty mapping value does (test_issue_25_00 above).
+        # Otherwise the comment lands on the sequence end and a second
+        # round-trip drifts it onto its own line, so dump(load(...)) is not
+        # idempotent.
+        first = round_trip_dump(round_trip_load('- null  # comment\n'))
+        second = round_trip_dump(round_trip_load(first))
+        assert first == second
+
+    def test_empty_seq_entries_keep_their_own_comments(self) -> None:
+        # with several empty entries each end-of-line comment must stay with
+        # its own entry rather than being collected at the end of the block.
+        data = round_trip_load('- null  # a\n- null  # b\n')
+        assert 0 in data.ca.items
+        assert 1 in data.ca.items
+        first = round_trip_dump(data)
+        second = round_trip_dump(round_trip_load(first))
+        assert first == second
+
 
 test_block_scalar_commented_line_template = """\
 y: p

--- a/_test/test_issues.py
+++ b/_test/test_issues.py
@@ -6,13 +6,13 @@ import pytest  # type: ignore  # NOQA
 
 # cannot do "from .roundtrip" because of pytest, so mypy cannot find this
 from roundtrip import (  # type: ignore
+    YAML,
     dedent,
     na_round_trip,
     round_trip,
     round_trip_dump,
     round_trip_load,
     save_and_run,
-    YAML,
 )
 
 

--- a/_test/test_z_data.py
+++ b/_test/test_z_data.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
-import sys
 import os
+import sys
 import warnings  # NOQA
 from pathlib import Path
 from typing import Any, List, Optional, Tuple

--- a/lib/ruyaml/composer.py
+++ b/lib/ruyaml/composer.py
@@ -7,13 +7,13 @@ from ruyaml.compat import nprint, nprintf  # NOQA
 from ruyaml.error import MarkedYAMLError, ReusedAnchorWarning
 from ruyaml.events import (
     AliasEvent,
-    MappingStartEvent,
     MappingEndEvent,
+    MappingStartEvent,
     ScalarEvent,
-    SequenceStartEvent,
     SequenceEndEvent,
-    StreamStartEvent,
+    SequenceStartEvent,
     StreamEndEvent,
+    StreamStartEvent,
 )
 from ruyaml.nodes import MappingNode, ScalarNode, SequenceNode
 

--- a/lib/ruyaml/constructor.py
+++ b/lib/ruyaml/constructor.py
@@ -8,29 +8,45 @@ import warnings
 from collections.abc import Hashable, MutableMapping, MutableSequence  # type: ignore
 from datetime import timedelta as TimeDelta
 
-# fmt: off
-from ruyaml.error import (MarkedYAMLError, MarkedYAMLFutureWarning,
-                          MantissaNoDotYAML1_1Warning)
-from ruyaml.nodes import *                               # NOQA
-from ruyaml.nodes import (SequenceNode, MappingNode, ScalarNode)
-from ruyaml.compat import (builtins_module, # NOQA
-                           nprint, nprintf, version_tnf)
-from ruyaml.compat import ordereddict
+from ruyaml.comments import *  # NOQA
+from ruyaml.comments import (
+    C_KEY_EOL,
+    C_KEY_POST,
+    C_KEY_PRE,
+    C_VALUE_EOL,
+    C_VALUE_POST,
+    C_VALUE_PRE,
+    CommentedKeyMap,
+    CommentedKeySeq,
+    CommentedMap,
+    CommentedOrderedMap,
+    CommentedSeq,
+    CommentedSet,
+    TaggedScalar,
+)
+from ruyaml.compat import builtins_module  # NOQA
+from ruyaml.compat import nprint, nprintf, ordereddict, version_tnf
 
-from ruyaml.tag import Tag
-from ruyaml.comments import *                               # NOQA
-from ruyaml.comments import (CommentedMap, CommentedOrderedMap, CommentedSet,
-                             CommentedKeySeq, CommentedSeq, TaggedScalar,
-                             CommentedKeyMap,
-                             C_KEY_PRE, C_KEY_EOL, C_KEY_POST,
-                             C_VALUE_PRE, C_VALUE_EOL, C_VALUE_POST,
-                             )
-from ruyaml.scalarstring import (SingleQuotedScalarString, DoubleQuotedScalarString,
-                                 LiteralScalarString, FoldedScalarString,
-                                 PlainScalarString, ScalarString)
-from ruyaml.scalarint import ScalarInt, BinaryInt, OctalInt, HexInt, HexCapsInt
-from ruyaml.scalarfloat import ScalarFloat
+# fmt: off
+from ruyaml.error import (
+    MantissaNoDotYAML1_1Warning,
+    MarkedYAMLError,
+    MarkedYAMLFutureWarning,
+)
+from ruyaml.nodes import *  # NOQA
+from ruyaml.nodes import MappingNode, ScalarNode, SequenceNode
 from ruyaml.scalarbool import ScalarBoolean
+from ruyaml.scalarfloat import ScalarFloat
+from ruyaml.scalarint import BinaryInt, HexCapsInt, HexInt, OctalInt, ScalarInt
+from ruyaml.scalarstring import (
+    DoubleQuotedScalarString,
+    FoldedScalarString,
+    LiteralScalarString,
+    PlainScalarString,
+    ScalarString,
+    SingleQuotedScalarString,
+)
+from ruyaml.tag import Tag
 from ruyaml.timestamp import TimeStamp
 from ruyaml.util import create_timestamp, timestamp_regexp
 

--- a/lib/ruyaml/main.py
+++ b/lib/ruyaml/main.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import glob
+import warnings
 from importlib import import_module
 from io import BytesIO, StringIO
 from typing import TYPE_CHECKING, Any, List, Optional, Text, Union
-import warnings
 
 import ruyaml
 from ruyaml.comments import C_PRE, CommentedMap, CommentedSeq
@@ -21,7 +21,6 @@ from ruyaml.error import UnsafeLoaderWarning, YAMLError  # NOQA
 from ruyaml.events import *  # NOQA
 from ruyaml.loader import BaseLoader  # NOQA
 from ruyaml.loader import Loader  # NOQA
-from ruyaml.loader import Loader as UnsafeLoader
 from ruyaml.loader import RoundTripLoader, SafeLoader  # NOQA
 from ruyaml.nodes import *  # NOQA
 from ruyaml.representer import (

--- a/lib/ruyaml/parser.py
+++ b/lib/ruyaml/parser.py
@@ -573,6 +573,29 @@ class Parser:
         self.marks.append(token.start_mark)
         return self.parse_block_sequence_entry()
 
+    def pop_eol_comment_for_empty_entry(self, token: Any) -> Any:
+        # An empty (null) block sequence entry has no value token for an
+        # end-of-line comment to attach to, so the scanner records that
+        # comment as one preceding the next token.  A comment that sits on
+        # the same line as the entry's '-' indicator is the eol comment of
+        # this (empty) entry and must stay attached to it; otherwise it
+        # drifts onto the block end and a second round-trip no longer
+        # reproduces the first (and, with several empty entries, the
+        # comments get reassigned to the wrong items).
+        if self.loader is None or self.loader.comment_handling is not None:
+            return None
+        nt = self.scanner.peek_token()
+        pre = nt.comment[1] if nt.comment else None
+        if not pre:
+            return None
+        for idx, ct in enumerate(pre):
+            if ct is not None and ct.start_mark.line == token.start_mark.line:
+                eol = pre.pop(idx)
+                if not pre:
+                    nt.comment[1] = None
+                return [eol, None]
+        return None
+
     def parse_block_sequence_entry(self) -> Any:
         if self.scanner.check_token(BlockEntryToken):
             token = self.scanner.get_token()
@@ -582,7 +605,8 @@ class Parser:
                 return self.parse_block_node()
             else:
                 self.state = self.parse_block_sequence_entry
-                return self.process_empty_scalar(token.end_mark)
+                comment = self.pop_eol_comment_for_empty_entry(token)
+                return self.process_empty_scalar(token.end_mark, comment=comment)
         if not self.scanner.check_token(BlockEndToken):
             token = self.scanner.peek_token()
             raise ParserError(
@@ -620,7 +644,10 @@ class Parser:
                 return self.parse_block_node()
             else:
                 self.state = self.parse_indentless_sequence_entry
-                return self.process_empty_scalar(token.end_mark)
+                # see parse_block_sequence_entry: keep an eol comment that
+                # sits on the same line as the '-' with this empty entry
+                comment = self.pop_eol_comment_for_empty_entry(token)
+                return self.process_empty_scalar(token.end_mark, comment=comment)
         token = self.scanner.peek_token()
         c = None
         if self.loader and self.loader.comment_handling is None:


### PR DESCRIPTION
While round-tripping some config files I hit a case where `dump(load(x))` isn't idempotent. A block sequence entry whose value is null/empty but carries an end-of-line comment moves the comment onto its own line on the second round-trip:

```python
import ruyaml, sys
yaml = ruyaml.YAML()
d = yaml.load("- null  # comment\n")
yaml.dump(d, sys.stdout)      # -> "-       # comment"
```

Reload that output and dump again and you get:

```
- 
        # comment
```

It's worse with several empty entries: their comments all slide down and end up attached to the wrong items.

Root cause: an empty entry has no value token for the eol comment to attach to, so the scanner queues it as a comment preceding the next token. `parse_block_sequence_entry` (and the indentless variant) then let it fall through to the sequence end instead of keeping it on the entry. Empty block *mapping* values (`a:  # comment`) already handle this correctly, so the sequence path was just missing the equivalent step.

The fix attaches a comment that sits on the same line as the `-` indicator to the empty entry itself, leaving genuine standalone comments (on their own line) alone.

Tested with two new cases in `_test/test_comments.py` covering the single-entry idempotency and the multi-entry attachment; the full `_test/test_*.py` suite still passes.